### PR TITLE
Fix error handling and struct tags

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -12,8 +12,8 @@ import (
 
 type TokenResponse struct {
 	Token     string `json:"token"`
-	FileToken string `json:"filetoken",omitempty`
-	FileName  string `json:"filename",omitempty`
+	FileToken string `json:"filetoken,omitempty"`
+	FileName  string `json:"filename,omitempty"`
 }
 
 type MsgReposne struct {
@@ -50,7 +50,7 @@ func (o *OTSecretSvc) CreateMsgHandler(ctx echo.Context) error {
 
 	// Handle the secret message
 	msg := ctx.FormValue("msg")
-	log.Println("msg recieved ", msg)
+	log.Println("msg received", msg)
 	token, err := CreateSecretMsg(o, []byte(msg))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "cannot create msg "+err.Error())

--- a/vault.go
+++ b/vault.go
@@ -9,7 +9,10 @@ import (
 
 func CreateSecretMsg(o *OTSecretSvc, msg []byte) (token []byte, err error) {
 	token, err = createOneTimeToken(o)
-	log.Println("writing msg ", string(msg), "with token", string(token))
+	if err != nil {
+		return nil, err
+	}
+	log.Println("writing msg", string(msg), "with token", string(token))
 	err = writeMsgToVault(token, msg)
 	if err != nil {
 		return nil, err
@@ -33,6 +36,7 @@ func createOneTimeToken(o *OTSecretSvc) ([]byte, error) {
 	})
 	if err != nil {
 		fmt.Println(err)
+		return nil, err
 	}
 	log.Println("got one time token : ", string([]byte(sec.Auth.ClientToken)))
 	return []byte(sec.Auth.ClientToken), err
@@ -49,7 +53,7 @@ func writeMsgToVault(token, msg []byte) error {
 
 	raw := map[string]interface{}{"msg": string(msg)}
 
-	log.Printf("writting message to vault at /cubbyhole/%s", string(token))
+	log.Printf("writing message to vault at /cubbyhole/%s", string(token))
 	otc.Logical().Write("/cubbyhole/"+string(token), raw)
 
 	return nil


### PR DESCRIPTION
createOneTimeToken prints the error but didn't return it
CreateSecretMsg also returns the error if the token cannot be created
golang expects struct tags as key:"value" pairs with value within quotes
some typo corrections