### PR TITLE
Add margin: 0 to body

### DIFF
--- a/static/application.css
+++ b/static/application.css
@@ -15,6 +15,7 @@ html,body {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0;
 }
 
 h1{


### PR DESCRIPTION
Firefox adding margin to body causing x and y overflow (visible scrollbars). Tested on FF92.