### PR TITLE
Renewal of vault auth token

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/vault/api"
@@ -20,7 +21,10 @@ type vault struct {
 
 // NewVault creates a vault client to talk with underline vault server
 func newVault(address string, prefix string, token string) vault {
-	return vault{address, prefix, token}
+	v := vault{address, prefix, token}
+
+	go v.newVaultClientToRenewToken()
+	return v
 }
 
 func (v vault) Store(msg string, ttl string) (token string, err error) {
@@ -36,7 +40,7 @@ func (v vault) Store(msg string, ttl string) (token string, err error) {
 	}
 
 	// validate duration length
-	if d > 168 * time.Hour || d == 0 * time.Hour  {
+	if d > 168*time.Hour || d == 0*time.Hour {
 		return "", fmt.Errorf("cannot set ttl to infinte or more than 7 days %v", err)
 	}
 
@@ -104,7 +108,7 @@ func (v vault) writeMsgToVault(token, msg string) error {
 
 	raw := map[string]interface{}{"msg": msg}
 
-	_, err = c.Logical().Write("/" + v.prefix + token, raw)
+	_, err = c.Logical().Write("/"+v.prefix+token, raw)
 
 	return err
 }
@@ -131,3 +135,43 @@ func (v vault) newVaultClientWithToken(token string) (*api.Client, error) {
 	return c, nil
 }
 
+func (v vault) newVaultClientToRenewToken() {
+	c, err := v.newVaultClient()
+	if err != nil {
+		log.Println(err)
+	}
+	client_auth_token := &api.Secret{Auth: &api.SecretAuth{ClientToken: c.Token(), Renewable: true}}
+
+	/* */
+	log.Println("renew cycle: begin")
+	defer log.Println("renew cycle: end")
+
+	// auth token
+	authTokenWatcher, err := c.NewLifetimeWatcher(&api.LifetimeWatcherInput{
+		Secret: client_auth_token,
+	})
+
+	if err != nil {
+		err := fmt.Errorf("unable to initialize auth token lifetime watcher: %w", err)
+		fmt.Println(err.Error())
+	}
+
+	go authTokenWatcher.Start()
+	defer authTokenWatcher.Stop()
+
+	// monitor events from both watchers
+	for {
+		select {
+
+		case err := <-authTokenWatcher.DoneCh():
+			// Leases created by a token get revoked when the token is revoked.
+			fmt.Println("Error is :", err)
+
+		// RenewCh is a channel that receives a message when a successful
+		// renewal takes place and includes metadata about the renewal.
+		case info := <-authTokenWatcher.RenewCh():
+			log.Printf("auth token: successfully renewed; remaining duration: %ds", info.Secret.Auth.LeaseDuration)
+		}
+	}
+
+}


### PR DESCRIPTION
Hi all , 

# Use case 

In general , teams don't use vault root token to access vault from this application (In their PROD env) . If those tokens are made renewable , we can periodically renew those tokens from vault client . So once those tokens are set and this application has been deployed , there wont be any downtime due to vault auth token expiration .

# Our scenario 

We have deployed this in our PROD env where it access PROD vault with a token ( max life time can be set to 32 days ) . So once that token expires , we need to create another token from vault and re-deploy this app with the new token . This creates some downtime for the application . 

# In this PR 

There is already an api in vault client ([NewLifeTimeWatcher](https://pkg.go.dev/github.com/hashicorp/vault/api#Client.NewLifetimeWatcher) ) which renews the secrets passed to it . I used code from this [function](https://github.com/hashicorp/hello-vault-go/blob/f54ade5fac861822e36a2b44c5511daf4ca650a0/sample-app/vault_renewal.go#L93) to call *NewLifeTimeWatcher* in a separate goroutine to renew vault auth token .

We can create renewable vault token with max_ttl_time 0s (no max_ttl ) and 32 days as expiration time by the following commands -
```
vault token create -policy=<POLICY_NAME> -period=768h
```
And then set it as VAULT_TOKEN env in docker image/container and deploy the app . This token is being used to access VAULT and when it nears its expiration time , it gets renewed by *NewLifeTimeWatcher* goroutine .

# Outputs 
<img width="781" alt="Screenshot 2023-02-19 at 4 32 24 PM" src="https://user-images.githubusercontent.com/28512151/219943999-29f50152-57b6-45b4-b4c0-f4ab2bfd2802.png">

Configuration used for this output -
1. created vault auth token with validity of 6 minutes . Thats why output says remaining duration: 360 s
2. Used docker-compose for running this app .(Set VAULT_TOKEN and VAULT_ADDR in docker-compose.yaml)


# Issue 
In case of root token which is being used in DEV mode , root tokens are not renewable so the output shows an error on its renewal for once .
<img width="684" alt="Screenshot 2023-02-19 at 4 44 49 PM" src="https://user-images.githubusercontent.com/28512151/219944503-29f88777-162a-4635-a860-90340cf7fa27.png">

Hope you people like this PR . I am open for any feedback .