### PR TITLE
Take advantages of echo middlewares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/vault v1.16.3
 	github.com/hashicorp/vault/api v1.14.0
 	github.com/labstack/echo/v4 v4.12.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0
 )
 
@@ -241,7 +242,6 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect

--- a/internal/vault.go
+++ b/internal/vault.go
@@ -31,17 +31,17 @@ func (v vault) Store(msg string, ttl string) (token string, err error) {
 	// Default TTL
 	if ttl == "" {
 		ttl = "48h"
-	}
+	} else {
+		// Verify duration
+		d, err := time.ParseDuration(ttl)
+		if err != nil {
+			return "", fmt.Errorf("cannot parse duration %v", err)
+		}
 
-	// Verify duration
-	d, err := time.ParseDuration(ttl)
-	if err != nil {
-		return "", fmt.Errorf("cannot parse duration %v", err)
-	}
-
-	// validate duration length
-	if d > 168*time.Hour || d == 0*time.Hour {
-		return "", fmt.Errorf("cannot set ttl to infinte or more than 7 days %v", err)
+		// validate duration length
+		if d > 168*time.Hour || d == 0*time.Hour {
+			return "", fmt.Errorf("cannot set ttl to infinte or more than 7 days %v", err)
+		}
 	}
 
 	t, err := v.createOneTimeToken(ttl)

--- a/internal/vault_test.go
+++ b/internal/vault_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	vaulthttp "github.com/hashicorp/vault/http"
 	hashivault "github.com/hashicorp/vault/vault"
+	"github.com/stretchr/testify/assert"
 )
 
 func createTestVault(t *testing.T) (net.Listener, *api.Client) {
@@ -24,14 +25,11 @@ func createTestVault(t *testing.T) (net.Listener, *api.Client) {
 	conf.Address = addr
 
 	c, err := api.NewClient(conf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.SetToken(rootToken)
 
-	_, err = c.Sys().Health()
-	if err != nil {
-		t.Fatal(err)
+	if assert.NoError(t, err) {
+		c.SetToken(rootToken)
+		_, err = c.Sys().Health()
+		assert.NoError(t, err)
 	}
 
 	return ln, c
@@ -44,17 +42,10 @@ func TestStoreAndGet(t *testing.T) {
 	v := newVault(c.Address(), "secret/test/", c.Token())
 	secret := "my secret"
 	token, err := v.Store(secret, "")
-	if err != nil {
-		t.Fatalf("no error expected, got %v", err)
-	}
-
-	msg, err := v.Get(token)
-	if err != nil {
-		t.Fatalf("no error expected, got %v", err)
-	}
-
-	if msg != secret {
-		t.Fatalf("expected message %s, got: %s", secret, msg)
+	if assert.NoError(t, err) {
+		msg, err := v.Get(token)
+		assert.NoError(t, err)
+		assert.Equal(t, secret, msg)
 	}
 }
 
@@ -65,17 +56,11 @@ func TestMsgCanOnlyBeAccessedOnce(t *testing.T) {
 	v := newVault(c.Address(), "secret/test/", c.Token())
 	secret := "my secret"
 	token, err := v.Store(secret, "")
-	if err != nil {
-		t.Fatalf("no error expected, got %v", err)
-	}
+	if assert.NoError(t, err) {
+		_, err = v.Get(token)
+		assert.NoError(t, err)
 
-	_, err = v.Get(token)
-	if err != nil {
-		t.Fatalf("no error expected, got %v", err)
-	}
-
-	_, err = v.Get(token)
-	if err == nil {
-		t.Fatal("error expected, got nil")
+		_, err = v.Get(token)
+		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
On top of https://github.com/algolia/sup3rS3cretMes5age/pull/103

- Add Recover and Rate Limit middlewares
- Do not log `/health` endpoint
- small optim: skip validation for hard coded default TTL

Fixes https://github.com/algolia/sup3rS3cretMes5age/issues/55
