### PR TITLE
docs: add contribution standards and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Report a reproducible problem in sup3rS3cretMes5age
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve sup3rS3cretMes5age.
+        Please provide as much detail as possible to help us reproduce and fix the issue quickly.
+
+        If this is a security vulnerability, do not create a public issue.
+        Please follow [SECURITY.md](../../SECURITY.md) and report it privately.
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: What is happening right now?
+      placeholder: A concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Please include a minimal reproducible case.
+      placeholder: |
+        1. Start the service with ...
+        2. Send request ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs-errors
+    attributes:
+      label: Logs, errors, or screenshots
+      description: Paste relevant output, stack traces, or screenshots.
+      render: shell
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      placeholder: e.g. go1.26.1
+    validations:
+      required: true
+
+  - type: input
+    id: docker-version
+    attributes:
+      label: Docker version
+      placeholder: e.g. Docker version 28.x
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. Ubuntu 24.04, macOS 15
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add anything else that may help (config/env vars, related issues, etc.).
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I can reproduce this issue with the steps provided above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/algolia/sup3rS3cretMes5age/security/advisories/new
+    about: Please report security vulnerabilities privately via GitHub Security Advisories.
+  - name: Contribution guide
+    url: https://github.com/algolia/sup3rS3cretMes5age/blob/master/CONTRIBUTING.md
+    about: Read contribution expectations, local setup, and validation checks.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Propose an improvement or new feature
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+        Please describe the use case and expected outcome.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: A clear description of the pain point.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you would like.
+      placeholder: How should this feature behave?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe alternative solutions or workarounds you've considered.
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact and scope
+      description: |
+        Explain expected impact and scope.
+        Mention if this could affect message lifecycle, Vault integration, API behavior, or backward compatibility.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add links, mockups, prior discussions, or related issues.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and did not find a duplicate request.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!--
+Thanks for submitting a pull request.
+Please provide enough detail so maintainers can review efficiently.
+-->
+
+## Summary
+
+<!--
+Explain the motivation for this change and what problem it solves.
+Link related issues/discussions when relevant.
+-->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Chore/maintenance
+- [ ] Breaking change
+
+## Validation
+
+List the exact commands you ran and their results.
+
+```bash
+gofmt -s -l .
+go vet ./...
+golangci-lint run --timeout 300s
+make test
+```
+
+Results:
+
+- [ ] `gofmt -s -l .` returns no output
+- [ ] `go vet ./...` passes
+- [ ] `golangci-lint run --timeout 300s` passes
+- [ ] `make test` passes
+
+## Manual checks
+
+If your change affects handlers, Vault integration, or message lifecycle, describe your end-to-end verification (create secret -> first read succeeds -> second read fails).
+
+## Checklist
+
+- [ ] Change is scoped and focused
+- [ ] Tests added/updated where needed
+- [ ] Docs updated if behavior/configuration changed
+- [ ] Commit messages follow Conventional Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to sup3rS3cretMes5age
+
+Thanks for your interest in contributing.
+
+This guide follows contribution patterns commonly used across Algolia repositories, adapted for this Go + Vault project.
+
+## Reporting an issue
+
+Opening an issue is one of the best ways to contribute.
+
+Before creating one:
+
+- Search existing issues to avoid duplicates.
+- Include your environment details (OS, Go version, Docker version).
+- Provide clear reproduction steps.
+- Include expected behavior and actual behavior.
+- If possible, include a minimal reproducible example.
+
+## Security issues
+
+If you believe you found a security vulnerability, please do not post exploit details publicly first. Follow [SECURITY.md](SECURITY.md) and open a private security report through GitHub Security Advisories for this repository.
+
+## Code contribution process
+
+For any code contribution:
+
+1. Open an issue first for non-trivial changes, behavior changes, or API-affecting updates.
+2. Fork and clone the repository.
+3. Create a dedicated branch (`fix/<issue-number>` or `feat/<short-description>`).
+4. Keep changes focused and small.
+5. Add or update tests.
+6. Open a pull request against `master`.
+
+Then:
+
+- CI checks will run automatically.
+- A maintainer will review your pull request.
+- Once checks are green and review is approved, the PR can be merged.
+
+## Commit conventions
+
+Use Conventional Commits:
+
+```text
+type(scope): description
+```
+
+Common types:
+
+- `fix`: bug fixes
+- `feat`: new features
+- `refactor`: code changes with no feature or bug fix
+- `docs`: documentation only
+- `chore`: tooling, CI, maintenance
+
+Examples:
+
+- `fix(vault): delete secret after successful read`
+- `feat(handler): support custom ttl parsing`
+- `docs(readme): clarify docker compose usage`
+
+If your commit resolves an issue, add a closing keyword in the commit body or PR description, for example `Closes #123`.
+
+## Development setup
+
+Requirements:
+
+- Go 1.26.1+
+- Docker
+- `curl`
+- `jq`
+
+Install dependencies:
+
+```bash
+go mod download
+```
+
+Build binary:
+
+```bash
+go build -o sup3rs3cret cmd/sup3rS3cretMes5age/main.go
+```
+
+## Running locally
+
+### Option 1: Docker Compose (recommended)
+
+```bash
+make run
+```
+
+App is exposed on `http://localhost:8082`.
+
+### Option 2: Local binary + Vault dev server
+
+Start Vault:
+
+```bash
+docker run -d --name vault-dev -p 8200:8200 \
+  -e VAULT_DEV_ROOT_TOKEN_ID=supersecret \
+  hashicorp/vault:latest
+```
+
+Run app:
+
+```bash
+VAULT_ADDR=http://localhost:8200 \
+VAULT_TOKEN=supersecret \
+SUPERSECRETMESSAGE_HTTP_BINDING_ADDRESS=":8080" \
+./sup3rs3cret
+```
+
+Cleanup:
+
+```bash
+docker stop vault-dev && docker rm vault-dev
+```
+
+## Testing and quality checks
+
+Run these before opening a pull request:
+
+```bash
+gofmt -s -l .
+go vet ./...
+golangci-lint run --timeout 300s
+make test
+```
+
+Expected results:
+
+- `gofmt -s -l .` returns no output.
+- `go vet`, `golangci-lint`, and `make test` complete without errors.
+
+## Manual validation
+
+After changes to request handling, Vault integration, or message lifecycle, validate end-to-end behavior:
+
+```bash
+TOKEN=$(curl -X POST -s -F 'msg=test secret message' http://localhost:8080/secret | jq -r .token)
+curl -s "http://localhost:8080/secret?token=$TOKEN" | jq .
+curl -s "http://localhost:8080/secret?token=$TOKEN" | jq .
+```
+
+The first read should return the secret, and the second read should fail because the message is self-destructing.
+
+## Pull request checklist
+
+- [ ] Change is scoped and focused.
+- [ ] Tests added or updated where needed.
+- [ ] `gofmt`, `go vet`, `golangci-lint`, and `make test` pass locally.
+- [ ] Docs updated if behavior or configuration changed.
+- [ ] PR description explains what changed and why.
+
+## License
+
+By contributing, you agree that your contributions are provided under the repository license (MIT).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied on a best-effort basis to:
+
+| Version | Supported |
+| --- | --- |
+| `master` (latest) | :white_check_mark: |
+| Older releases | :x: |
+
+If a vulnerability affects an unsupported version, upgrade to the latest release before requesting a fix.
+
+## Reporting a vulnerability
+
+Please do not open public issues for suspected security vulnerabilities.
+
+Use GitHub Security Advisories for private reporting:
+
+1. Go to the repository Security tab.
+2. Click "Report a vulnerability".
+3. Share detailed reproduction steps and impact.
+
+If private reporting through GitHub is unavailable, contact maintainers through repository ownership channels and include "Security" in the subject.
+
+## What to include in your report
+
+To help maintainers triage quickly, include:
+
+- A clear description of the vulnerability and potential impact.
+- Reproduction steps or a proof of concept.
+- Affected commit/tag/version.
+- Environment details (OS, Go version, Docker version, deployment mode).
+- Any suggested remediation (optional).
+
+Do not include production secrets, credentials, or personal data in your report.
+
+## Response and disclosure process
+
+Maintainers aim to:
+
+- Acknowledge new reports within 5 business days.
+- Triage severity and affected scope.
+- Work on a fix and coordinate release timing.
+- Credit the reporter unless anonymous disclosure is requested.
+
+Please allow time for a fix before public disclosure. Coordinated disclosure helps protect users.
+
+## Scope notes for this project
+
+This service handles sensitive one-time messages and Vault tokens. Reports are especially valuable for issues related to:
+
+- Secret leakage (logs, responses, storage, transport).
+- Token misuse or replay that breaks one-time read guarantees.
+- Authentication/authorization bypass in Vault interactions.
+- TLS misconfiguration that can expose secrets in transit.
+- File upload handling weaknesses (size limits, validation, processing).
+
+## Non-security bugs
+
+For non-security bugs, use the public issue templates in [bug_report.yml](.github/ISSUE_TEMPLATE/bug_report.yml) and [feature_request.yml](.github/ISSUE_TEMPLATE/feature_request.yml).


### PR DESCRIPTION
## Summary
Add repository contribution standards and GitHub collaboration templates.

## Changes
- add CONTRIBUTING.md with contribution process, commit conventions, and validation steps
- add SECURITY.md with private vulnerability disclosure workflow
- add PR template
- add bug/feature issue forms and issue template config

## Validation
- reviewed for consistency across CONTRIBUTING.md, SECURITY.md, and templates

## Notes
- intentionally scoped to documentation and GitHub workflow files only